### PR TITLE
Add scheduled task scaling for staging

### DIFF
--- a/groups/ecs-service/locals.tf
+++ b/groups/ecs-service/locals.tf
@@ -5,7 +5,7 @@ locals {
   service_name              = "dapperdox-developer"
   container_port            = "10000"
   docker_repo               = "dapperdox.developer.ch.gov.uk"
-  lb_listener_rule_priority = 100
+  lb_listener_rule_priority = 10
   lb_listener_paths         = ["/*"]
   vpc_name                  = data.aws_ssm_parameter.secret[format("/%s/%s", local.name_prefix, "vpc-name")].value
 

--- a/groups/ecs-service/main.tf
+++ b/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git::git@github.com:companieshouse/terraform-library-ecs-service.git?ref=1.0.2"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.206"
 
   # Environmental configuration
   environment             = var.environment
@@ -29,9 +29,10 @@ module "ecs-service" {
   task_execution_role_arn = data.aws_iam_role.ecs-cluster-iam-role.arn
 
   # Load balancer configuration
-  lb_listener_arn           = data.aws_lb_listener.dev-specs-lb-listener.arn
-  lb_listener_rule_priority = local.lb_listener_rule_priority
-  lb_listener_paths         = local.lb_listener_paths
+  lb_listener_arn                 = data.aws_lb_listener.dev-specs-lb-listener.arn
+  lb_listener_rule_priority       = local.lb_listener_rule_priority
+  lb_listener_paths               = local.lb_listener_paths
+  healthcheck_path                = "/"
 
   # Docker container details
   docker_registry   = var.docker_registry
@@ -44,9 +45,12 @@ module "ecs-service" {
   name_prefix  = local.name_prefix
 
   # Service performance and scaling configs
-  desired_task_count = var.desired_task_count
-  required_cpus      = var.required_cpus
-  required_memory    = var.required_memory
+  desired_task_count         = var.desired_task_count
+  required_cpus              = var.required_cpus
+  required_memory            = var.required_memory
+  service_autoscale_enabled  = var.service_autoscale_enabled
+  service_scaledown_schedule = var.service_scaledown_schedule
+  service_scaleup_schedule   = var.service_scaleup_schedule
 
   # Service environment variable and secret configs
   task_environment = local.task_environment

--- a/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -10,3 +10,8 @@ log_level = "trace"
 include_api_filing_public_specs = "1"
 include_pending_public_specs = "1"
 include_private_specs = "1"
+
+# Scheduled scaling of tasks
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/groups/ecs-service/variables.tf
+++ b/groups/ecs-service/variables.tf
@@ -62,6 +62,27 @@ variable "required_memory" {
   description = "The required memory for this service"
   default = 128 # defaulted low for dev environments, override for production
 }
+variable "service_autoscale_enabled" {
+  type        = bool
+  description = "Whether to enable service autoscaling, including scheduled autoscaling"
+  default     = false
+}
+variable "service_scaledown_schedule" {
+  type        = string
+  description = "The schedule to use when scaling down the number of tasks to zero."
+  # Typically used to stop all tasks in a service to save resource costs overnight.
+  # E.g. a value of '55 19 * * ? *' would be Mon-Sun 7:55pm.  An empty string indicates that no schedule should be created.
+
+  default     = ""
+}
+variable "service_scaleup_schedule" {
+  type        = string
+  description = "The schedule to use when scaling up the number of tasks to their normal desired level."
+  # Typically used to start all tasks in a service after it has been shutdown overnight.
+  # E.g. a value of '5 6 * * ? *' would be Mon-Sun 6:05am.  An empty string indicates that no schedule should be created.
+
+  default     = ""
+}
 
 # ------------------------------------------------------------------------------
 # Service environment variable configs


### PR DESCRIPTION
Adds a scheduled shutdown/startup on staging.

- Uses the module ecs-service from terraform-modules instead of terraform-library-ecs-service to bring in service auto-scaling feature.  
- Adjusts the lb rule priority to match the current active setting as the new ecs-service module uses "amped" (x10) values.
- Configures an overnight shutdown/startup schedule for the service on staging only, so that the number of tasks is scaled to zero just before the scheduled ASG scale down happens, and scaled up to the desired count just after the ASG scale up happens.

Auto-scaling based on tracking of target metrics has not been enabled at this stage, as there is currently an issue with the performance of dapperdox application that needs addressing first (https://companieshouse.atlassian.net/browse/CC-842) 

Partially resolves:
https://companieshouse.atlassian.net/browse/CC-198